### PR TITLE
Added os_ver 6.0 and 7.0 support to faz_dvm_cmd_add_device and faz_dvm_cmd_add_devlist

### DIFF
--- a/plugins/modules/faz_dvm_cmd_add_device.py
+++ b/plugins/modules/faz_dvm_cmd_add_device.py
@@ -158,6 +158,8 @@ options:
                             - '3.0'
                             - '4.0'
                             - '5.0'
+                            - '6.0'
+                            - '7.0'
                     patch:
                         type: int
                         description: '<i>add model device only</i>.'
@@ -1012,7 +1014,9 @@ def main():
                                 '2.0',
                                 '3.0',
                                 '4.0',
-                                '5.0'
+                                '5.0',
+                                '6.0',
+                                '7.0'
                             ],
                             'type': 'str'
                         },

--- a/plugins/modules/faz_dvm_cmd_add_devlist.py
+++ b/plugins/modules/faz_dvm_cmd_add_devlist.py
@@ -155,6 +155,8 @@ options:
                             - '3.0'
                             - '4.0'
                             - '5.0'
+                            - '6.0'
+                            - '7.0'
                     patch:
                         type: int
                         description: '<i>add model device only</i>.'
@@ -982,7 +984,9 @@ def main():
                                 '2.0',
                                 '3.0',
                                 '4.0',
-                                '5.0'
+                                '5.0',
+                                '6.0',
+                                '7.0'
                             ],
                             'type': 'str'
                         },


### PR DESCRIPTION
Hi!

Since at this moment `faz_dvm_cmd_add_device` and `faz_dvm_cmd_add_devlist` only support listed versions as `os_ver` values:
```
- 'unknown',
- '0.0',
- '1.0',
- '2.0',
- '3.0',
- '4.0',
- '5.0'
```
I've added support for version `6.0` and `7.0` to `faz_dvm_cmd_add_device` and `faz_dvm_cmd_add_devlist`. Ran a test as well and everything is working as expected.

Results:
```
changed: [fortianalyzer01] => {
    "changed": true,
    "invocation": {
        "module_args": {
            "access_token": null,
            "bypass_validation": false,
            "dvm_cmd_add_device": {
                "adom": "ansible-test-2",
                "device": {
                    "adm_pass": null,
                    "adm_usr": null,
                    "desc": null,
                    "device action": "add_model",
                    "faz.quota": null,
                    "ip": null,
                    "meta fields": null,
                    "mgmt_mode": "faz",
                    "mr": 2,
                    "name": "fgt40f",
                    "os_type": "fos",
                    "os_ver": "7.0",
                    "patch": null,
                    "platform_str": null,
                    "sn": "FGT40XXXX"
                },
                "flags": null,
                "groups": null
            },
            "enable_log": false,
            "forticloud_access_token": null,
            "log_path": "/tmp/fortianalyzer.ansible.log",
            "rc_failed": null,
            "rc_succeeded": null
        }
    },
    "meta": {
        "request_url": "/dvm/cmd/add/device",
        "response_code": 0,
        "response_data": {
            "device": {
                "beta": -1,
                "conn_mode": 1,
                "dev_status": 1,
                "flags": 67371008,
                "hostname": "FGT40XXXXX",
                "maxvdom": 10,
                "mgmt_mode": 2,
                "mgmt_uuid": "392100547",
                "mr": 2,
                "name": "fgt40f",
                "oid": 208,
                "os_type": 0,
                "os_ver": 7,
                "patch": -1,
                "platform_id": 6,
                "platform_str": "FortiGate-40F",
                "sn": "FGT40XXXXX",
                "source": 1,
                "tab_status": "<unknown>"
            }
        },
        "response_message": "OK",
        "system_information": {
            "Admin Domain Configuration": "Enabled",
            "BIOS version": "04000002",
            "Branch Point": "1460",
            "Build": "1460",
            "Current Time": "Tue Nov 14 13:25:14 EET 2023",
            "Daylight Time Saving": "Yes",
            "Disk Usage": "Free 139.33GB, Total 146.64GB",
            "FIPS Mode": "Disabled",
            "Hostname": "FAZ",
            "License Status": "Valid",
            "Major": 7,
            "Max Number of Admin Domains": 2,
            "Minor": 2,
            "Patch": 4,
            "Platform Full Name": "FortiAnalyzer-VM64-HV",
            "Platform Type": "FAZVM64-HV",
            "Release Version Information": " (GA)",
            "Serial Number": "FAZ-XXXXX",
            "TZ": "Europe/Helsinki",
            "Time Zone": "(GMT+2:00) Helsinki, Riga,Tallinn.",
            "Version": "v7.2.4-build1460 230926 (GA)",
            "x86-64 Applications": "Yes"
        }
    },
    "rc": 0
}
```